### PR TITLE
Remove npm ci from the Command:

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: ./Gita/
     steps:
       - uses: actions/checkout@v4
-      - run: npm install --legacy-peer-deps && npm ci && npm run build
+      - run: npm install --legacy-peer-deps && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -12,7 +12,7 @@ jobs:
         working-directory: ./Gita/
     steps:
       - uses: actions/checkout@v4
-      - run: npm install && npm ci && npm run build
+      - run: npm install --legacy-peer-deps && npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Since we've already installed the dependencies with npm install --legacy-peer-deps, running npm ci immediately after is not only redundant but also counterproductive in this context. Instead, we should directly proceed to building our project after the dependencies have been installed.