### PR TITLE
resolve error CLI for webpack must be installed.

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -41,7 +41,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - run: npm install --legacy-peer-deps && npm run build
+      - run: npm install --legacy-peer-deps
+        working-directory: ./Gita/
+
+      - name: Install webpack-cli
+        run: npm install -D webpack-cli
+        working-directory: ./Gita/
+
+      - run: npm run build
         working-directory: ./Gita/
 
       - name: Firebase Extended
@@ -52,3 +59,4 @@ jobs:
           channelId: live
           projectId: gita1a
           entryPoint: ./Gita/
+


### PR DESCRIPTION
CLI for webpack must be installed.
[52](https://github.com/kuldeep1A/Gita/actions/runs/8469627613/job/23205393215#step:5:53)
  webpack-cli (https://github.com/webpack/webpack-cli)
[53](https://github.com/kuldeep1A/Gita/actions/runs/8469627613/job/23205393215#step:5:54)

[54](https://github.com/kuldeep1A/Gita/actions/runs/8469627613/job/23205393215#step:5:55)
We will use "npm" to install the CLI via "npm install -D webpack-cli".
[55](https://github.com/kuldeep1A/Gita/actions/runs/8469627613/job/23205393215#step:5:56)
Do you want to install 'webpack-cli' (yes/no): 
[56](https://github.com/kuldeep1A/Gita/actions/runs/8469627613/job/23205393215#step:5:57)
Error: Process completed with exit code 1.